### PR TITLE
adds the autocaptured image to the product not found delegate function

### DIFF
--- a/Example/OTOnexus/ScanViewController.swift
+++ b/Example/OTOnexus/ScanViewController.swift
@@ -61,7 +61,7 @@ class ScanViewController: UIViewController, OTOCaptureViewDelegate {
         }
     }
 
-    func scannedBarcodeDoesNotExist(barcode: String) {
+    func scannedBarcodeDoesNotExist(barcode: String, image:UIImage) {
         OTOSession.startSession(withExperienceId: ApiConfiguration.sampleExperienceId, barcode: barcode) { (session, error) in
             if let session = session {
                 print("Session Page", session.page)

--- a/OTOnexus/Classes/capture/CaptureView.swift
+++ b/OTOnexus/Classes/capture/CaptureView.swift
@@ -15,7 +15,7 @@ public protocol OTOCaptureViewDelegate: class {
     func didCapture(product:OTOProduct)
     
     /// Delegate method that returns when a scanned barcode does not exist on the *121nexus Platform*
-    func scannedBarcodeDoesNotExist(barcode:String)
+    func scannedBarcodeDoesNotExist(barcode:String, image:UIImage)
     
     func didEncounterError(error: OTOError)
     
@@ -104,7 +104,7 @@ extension OTOCaptureView : CaptureViewInternalDelegate {
             } else if let error = error {
                 switch error {
                 case .productNotFound:
-                    self.delegate?.scannedBarcodeDoesNotExist(barcode: barcode)
+                    self.delegate?.scannedBarcodeDoesNotExist(barcode: barcode, image: image)
                 case .otoError(let otoError):
                     self.delegate?.didEncounterError(error: otoError)
                 }


### PR DESCRIPTION
Previously the auto-captured image was only available on `OTOProduct` which was only available if a product was found