### PR TITLE
stops capture session before starting another

### DIFF
--- a/OTOnexus/Classes/Capture/OTOCaptureView.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureView.swift
@@ -181,6 +181,11 @@ class OTOCaptureView: UIView, AVCaptureMetadataOutputObjectsDelegate {
         }
     }
     
+    func stopCapture() {
+        guard let captureSession = captureSession else { return }
+        captureSession.stopRunning()
+    }
+    
     func toggleFlash() {
         guard let captureDevice = captureDevice else {return}
         if (captureDevice.hasTorch) {

--- a/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
@@ -57,6 +57,11 @@ public class OTOCaptureViewController: UIViewController {
         captureView?.startCaptureIfNotRunning()
     }
     
+    override public func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        captureView?.stopCapture()
+    }
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
         NotificationCenter.default.addObserver(self, selector: #selector(handleForgrounding), name: .UIApplicationDidBecomeActive, object: nil)


### PR DESCRIPTION
There is anther error that I could observer and attempt to restart the capture session, but after I added this stop capture I couldn't reproduce.