### PR TITLE
Add OTOBarcode/Type struct and enum

### DIFF
--- a/OTOnexus/Classes/Capture/OTOCaptureView.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureView.swift
@@ -303,8 +303,8 @@ class OTOCaptureView: UIView {
     fileprivate func didCapture(barcode: OTOBarcode) {
         OTOProduct.search(barcode: barcode) { (product, error) in
             if let product = product {
-                product.capturedImage = barcode.image
-                self.delegate?.didCapture(product: product, barcode: barcode)
+                product.barcode = barcode
+                self.delegate?.didCapture(product: product)
             } else if let error = error {
                 switch error {
                 case .productNotFound:

--- a/OTOnexus/Classes/Capture/OTOCaptureView.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureView.swift
@@ -286,6 +286,7 @@ class OTOCaptureView: UIView {
     }
     
     fileprivate func finishBarcodeScan(barcode: OTOBarcode) {
+        var barcode = barcode
         scanStatus = Status.completed
         previewBox.green()
         //Take photo of scan to be sent to platform//
@@ -293,20 +294,21 @@ class OTOCaptureView: UIView {
         if (delegate != nil) {
             //Take photo of scan to be sent to platform//
             takePhoto(capturedImage: { (image) in
-                self.didCapture(barcode: barcode, image: image)
+                barcode.image = image
+                self.didCapture(barcode: barcode)
             })
         }
     }
     
-    fileprivate func didCapture(barcode: OTOBarcode, image: UIImage) {
+    fileprivate func didCapture(barcode: OTOBarcode) {
         OTOProduct.search(barcode: barcode) { (product, error) in
             if let product = product {
-                product.capturedImage = image
+                product.capturedImage = barcode.image
                 self.delegate?.didCapture(product: product, barcode: barcode)
             } else if let error = error {
                 switch error {
                 case .productNotFound:
-                    self.delegate?.scannedBarcodeDoesNotExist(barcode: barcode, image: image)
+                    self.delegate?.scannedBarcodeDoesNotExist(barcode: barcode)
                 case .otoError(let otoError):
                     self.delegate?.didEncounterError(error: otoError)
                 }

--- a/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
@@ -13,9 +13,8 @@ public protocol OTOCaptureViewDelegate: class {
      Delegate method that returns the results of a scanned barcode.
      - Parameters:
         - product: the product mapped to the recognized barcode
-        - barcode: structured information about the scanned barcode
      */
-    func didCapture(product: OTOProduct, barcode: OTOBarcode)
+    func didCapture(product: OTOProduct)
     
     /**
      Delegate method that returns when a scanned barcode does not exist on the *121nexus Platform*

--- a/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
@@ -21,9 +21,8 @@ public protocol OTOCaptureViewDelegate: class {
      Delegate method that returns when a scanned barcode does not exist on the *121nexus Platform*
      - Parameters:
          - barcode: structured information about the scanned barcode
-         - image: an image of the barcode automatically captured as part of the scan
      */
-    func scannedBarcodeDoesNotExist(barcode: OTOBarcode, image: UIImage)
+    func scannedBarcodeDoesNotExist(barcode: OTOBarcode)
 
     /**
      Delegate method called if some other error occurred, e.g. networking or authentication.

--- a/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
@@ -9,12 +9,26 @@ import UIKit
 
 public protocol OTOCaptureViewDelegate: class {
     
-    /// Delegate method that returns the results of a scanned barcode and takes a parameter of a *product*
-    func didCapture(product:OTOProduct)
+    /**
+     Delegate method that returns the results of a scanned barcode.
+     - Parameters:
+        - product: the product mapped to the recognized barcode
+        - barcode: structured information about the scanned barcode
+     */
+    func didCapture(product: OTOProduct, barcode: OTOBarcode)
     
-    /// Delegate method that returns when a scanned barcode does not exist on the *121nexus Platform*
-    func scannedBarcodeDoesNotExist(barcode:String, image:UIImage)
-    
+    /**
+     Delegate method that returns when a scanned barcode does not exist on the *121nexus Platform*
+     - Parameters:
+         - barcode: structured information about the scanned barcode
+         - image: an image of the barcode automatically captured as part of the scan
+     */
+    func scannedBarcodeDoesNotExist(barcode: OTOBarcode, image: UIImage)
+
+    /**
+     Delegate method called if some other error occurred, e.g. networking or authentication.
+     - Parameter error: description of the error
+     */
     func didEncounterError(error: OTOError)
     
 }

--- a/OTOnexus/Classes/Models/Barcodes.swift
+++ b/OTOnexus/Classes/Models/Barcodes.swift
@@ -1,0 +1,97 @@
+//
+//  Barcodes.swift
+//  OTOnexus
+//
+//  Created by Andrew McKnight on 2/8/18.
+//
+
+import AVFoundation
+import Foundation
+
+public struct OTOBarcode: Equatable {
+    public var data: String
+    public var type: OTOBarcodeType
+}
+
+extension OTOBarcode: Hashable {
+    public var hashValue: Int {
+        return "\(type.rawValue):\(data)".hashValue
+    }
+}
+
+public func ==(lhs: OTOBarcode, rhs: OTOBarcode) -> Bool {
+    return lhs.data == rhs.data && lhs.type == rhs.type
+}
+
+// MARK: Barcode types
+public enum OTOBarcodeType: String {
+    case code_128_Concatenated = "Code 128 concatenated"
+    case code_128_Stacked = "Code 128 stacked"
+    case dataMatrix = "DataMatrix"
+    case EAN_UPC = "EAN/UPC"
+    case ITF‌_14 = "_ITF-14_"
+    case GS1_Databar = "GS1 Databar"
+    case QR_Code = "QR Code"
+
+    #if swift(>=4)
+        init?(metadataType: AVMetadataObject.ObjectType) {
+            switch metadataType {
+            case AVMetadataObject.ObjectType.qr: self = .QR_Code
+            case AVMetadataObject.ObjectType.dataMatrix: self = .dataMatrix
+            case AVMetadataObject.ObjectType.code128: self = .code_128_Concatenated
+            case AVMetadataObject.ObjectType.code39: return nil
+            case AVMetadataObject.ObjectType.code93: return nil
+            case AVMetadataObject.ObjectType.upce: return nil
+            case AVMetadataObject.ObjectType.pdf417: return nil
+            case AVMetadataObject.ObjectType.ean13: return nil
+            case AVMetadataObject.ObjectType.aztec: return nil
+            case AVMetadataObject.ObjectType.itf14: self = .ITF‌_14
+            default: return nil
+            }
+        }
+
+        static var supportedBarcodes: [AVMetadataObject.ObjectType] {
+            return [
+                AVMetadataObject.ObjectType.qr,
+                AVMetadataObject.ObjectType.dataMatrix,
+                AVMetadataObject.ObjectType.code128,
+                AVMetadataObject.ObjectType.code39,
+                AVMetadataObject.ObjectType.code93,
+                AVMetadataObject.ObjectType.upce,
+                AVMetadataObject.ObjectType.pdf417,
+                AVMetadataObject.ObjectType.ean13,
+                AVMetadataObject.ObjectType.aztec,
+                AVMetadataObject.ObjectType.itf14,
+            ]
+        }
+    #else
+        init?(metadataType: AVMetadataObjectType) {
+            if metadataType as String == AVMetadataObjectTypeQRCode { self = .QR_Code }
+            else if metadataType as String == AVMetadataObjectTypeDataMatrixCode { self = .dataMatrix }
+            else if metadataType as String == AVMetadataObjectTypeCode128Code { self = .code_128_Concatenated }
+            else if metadataType as String == AVMetadataObjectTypeCode39Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeCode93Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeUPCECode { return nil }
+            else if metadataType as String == AVMetadataObjectTypePDF417Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeEAN13Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeAztecCode { return nil }
+            else if metadataType as String == AVMetadataObjectTypeITF14Code { self = .ITF‌_14 }
+            else { return nil }
+        }
+
+        static var supportedBarcodes: [AVMetadataObjectType] {
+            return [
+                AVMetadataObjectTypeQRCode as NSString,
+                AVMetadataObjectTypeDataMatrixCode as NSString,
+                AVMetadataObjectTypeCode128Code as NSString,
+                AVMetadataObjectTypeCode39Code as NSString,
+                AVMetadataObjectTypeCode93Code as NSString,
+                AVMetadataObjectTypeUPCECode as NSString,
+                AVMetadataObjectTypePDF417Code as NSString,
+                AVMetadataObjectTypeEAN13Code as NSString,
+                AVMetadataObjectTypeAztecCode as NSString,
+                AVMetadataObjectTypeITF14Code as NSString,
+            ]
+        }
+    #endif
+}

--- a/OTOnexus/Classes/Models/Modules/OTOCustomValidationModule.swift
+++ b/OTOnexus/Classes/Models/Modules/OTOCustomValidationModule.swift
@@ -20,7 +20,7 @@ public class OTOCustomValidationModule : OTOModule {
     /// Function to validate barcode data using custom validation rules
     public func validateBarcode(complete: @escaping (OTOCustomValidateBarcodeResponse?, OTOError?) -> Void) {
         if let barcode = session?.barcode {
-            validateBarcodeAction?.barcode = barcode
+            validateBarcodeAction?.barcode = barcode.data
         }
         validateBarcodeAction?.perform(complete: { [weak self] (barcodeResponse, error) in
             guard let strongSelf = self else { return }

--- a/OTOnexus/Classes/Models/Modules/OTOGs1ValidationModule.swift
+++ b/OTOnexus/Classes/Models/Modules/OTOGs1ValidationModule.swift
@@ -20,7 +20,7 @@ public class OTOGs1ValidationModule : OTOModule {
     /// Function to validate barcode data using GS1 validation rules
     public func validateBarcode(complete: @escaping (OTOValidateBarcodeResponse?, OTOError?) -> Void) {
         if let barcode = session?.barcode {
-            validateBarcodeAction?.barcode = barcode
+            validateBarcodeAction?.barcode = barcode.data
         }
         validateBarcodeAction?.perform(complete: { [weak self] (barcodeResponse, error) in
             guard let strongSelf = self else { return }

--- a/OTOnexus/Classes/Models/OTOBarcode.swift
+++ b/OTOnexus/Classes/Models/OTOBarcode.swift
@@ -1,0 +1,29 @@
+//
+//  OTOBarcode.swift
+//  OTOnexus
+//
+//  Created by Andrew McKnight on 2/14/18.
+//
+
+import UIKit
+
+public struct OTOBarcode: Equatable {
+    public var data: String
+    public var type: OTOBarcodeType
+    public var image: UIImage?
+
+    init(data: String, type: OTOBarcodeType) {
+        self.data = data
+        self.type = type
+    }
+}
+
+extension OTOBarcode: Hashable {
+    public var hashValue: Int {
+        return "\(type.rawValue):\(data)".hashValue
+    }
+}
+
+public func ==(lhs: OTOBarcode, rhs: OTOBarcode) -> Bool {
+    return lhs.data == rhs.data && lhs.type == rhs.type
+}

--- a/OTOnexus/Classes/Models/OTOBarcodeType.swift
+++ b/OTOnexus/Classes/Models/OTOBarcodeType.swift
@@ -1,5 +1,5 @@
 //
-//  Barcodes.swift
+//  OTOBarcodeType.swift
 //  OTOnexus
 //
 //  Created by Andrew McKnight on 2/8/18.
@@ -8,22 +8,6 @@
 import AVFoundation
 import Foundation
 
-public struct OTOBarcode: Equatable {
-    public var data: String
-    public var type: OTOBarcodeType
-}
-
-extension OTOBarcode: Hashable {
-    public var hashValue: Int {
-        return "\(type.rawValue):\(data)".hashValue
-    }
-}
-
-public func ==(lhs: OTOBarcode, rhs: OTOBarcode) -> Bool {
-    return lhs.data == rhs.data && lhs.type == rhs.type
-}
-
-// MARK: Barcode types
 public enum OTOBarcodeType: String {
     case code_128_Concatenated = "Code 128 concatenated"
     case code_128_Stacked = "Code 128 stacked"
@@ -32,7 +16,10 @@ public enum OTOBarcodeType: String {
     case ITF‌_14 = "_ITF-14_"
     case GS1_Databar = "GS1 Databar"
     case QR_Code = "QR Code"
+}
 
+// MARK: Init
+extension OTOBarcodeType {
     #if swift(>=4)
         init?(metadataType: AVMetadataObject.ObjectType) {
             switch metadataType {
@@ -49,7 +36,26 @@ public enum OTOBarcodeType: String {
             default: return nil
             }
         }
+    #else
+        init?(metadataType: AVMetadataObjectType) {
+            if metadataType as String == AVMetadataObjectTypeQRCode { self = .QR_Code }
+            else if metadataType as String == AVMetadataObjectTypeDataMatrixCode { self = .dataMatrix }
+            else if metadataType as String == AVMetadataObjectTypeCode128Code { self = .code_128_Concatenated }
+            else if metadataType as String == AVMetadataObjectTypeCode39Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeCode93Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeUPCECode { return nil }
+            else if metadataType as String == AVMetadataObjectTypePDF417Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeEAN13Code { return nil }
+            else if metadataType as String == AVMetadataObjectTypeAztecCode { return nil }
+            else if metadataType as String == AVMetadataObjectTypeITF14Code { self = .ITF‌_14 }
+            else { return nil }
+        }
+    #endif
+}
 
+// MARK: Supported barcodes
+extension OTOBarcodeType {
+    #if swift(>=4)
         static var supportedBarcodes: [AVMetadataObject.ObjectType] {
             return [
                 AVMetadataObject.ObjectType.qr,
@@ -65,20 +71,6 @@ public enum OTOBarcodeType: String {
             ]
         }
     #else
-        init?(metadataType: AVMetadataObjectType) {
-            if metadataType as String == AVMetadataObjectTypeQRCode { self = .QR_Code }
-            else if metadataType as String == AVMetadataObjectTypeDataMatrixCode { self = .dataMatrix }
-            else if metadataType as String == AVMetadataObjectTypeCode128Code { self = .code_128_Concatenated }
-            else if metadataType as String == AVMetadataObjectTypeCode39Code { return nil }
-            else if metadataType as String == AVMetadataObjectTypeCode93Code { return nil }
-            else if metadataType as String == AVMetadataObjectTypeUPCECode { return nil }
-            else if metadataType as String == AVMetadataObjectTypePDF417Code { return nil }
-            else if metadataType as String == AVMetadataObjectTypeEAN13Code { return nil }
-            else if metadataType as String == AVMetadataObjectTypeAztecCode { return nil }
-            else if metadataType as String == AVMetadataObjectTypeITF14Code { self = .ITF‌_14 }
-            else { return nil }
-        }
-
         static var supportedBarcodes: [AVMetadataObjectType] {
             return [
                 AVMetadataObjectTypeQRCode as NSString,

--- a/OTOnexus/Classes/Models/OTOProduct.swift
+++ b/OTOnexus/Classes/Models/OTOProduct.swift
@@ -25,8 +25,6 @@ public class OTOProduct {
     public typealias ProductCompleteBlock = (OTOProduct?, ProductError?) -> Void
     /// The associated barcode data and type
     public var barcode:OTOBarcode?
-    /// Auto captured image during scanning
-    public var capturedImage:UIImage?
     /// A product url
     public var url = ""
     /// Dictionary of attributes of a product

--- a/OTOnexus/Classes/Models/OTOProduct.swift
+++ b/OTOnexus/Classes/Models/OTOProduct.swift
@@ -23,8 +23,8 @@ public class OTOProduct {
         case otoError(OTOError)
     }
     public typealias ProductCompleteBlock = (OTOProduct?, ProductError?) -> Void
-    /// A barcode's raw data string
-    public var barcodeData:String?
+    /// The associated barcode data and type
+    public var barcode:OTOBarcode?
     /// Auto captured image during scanning
     public var capturedImage:UIImage?
     /// A product url
@@ -46,12 +46,12 @@ public class OTOProduct {
     /**
      Search for product with barcodeData
      */
-    public static func search(barcodeData:String,
+    public static func search(barcode:OTOBarcode,
                               complete:@escaping ProductCompleteBlock) {
-        self.search(withParams: ["barcode_data": barcodeData],
+        self.search(withParams: ["barcode_data": barcode.data],
                     complete: { (product, error) in
                         if let product = product {
-                            product.barcodeData = barcodeData
+                            product.barcode = barcode
                             complete(product, nil)
                         } else {
                             complete(product, error)

--- a/OTOnexus/Classes/Models/OTOSession.swift
+++ b/OTOnexus/Classes/Models/OTOSession.swift
@@ -25,8 +25,8 @@ public class OTOSession {
     public var page = [OTOModule]()
     /// A product on the 121 platform
     public var product:OTOProduct?
-    /// A barcode's raw string value
-    public var barcode:String?
+    /// A scanned barcode
+    public var barcode:OTOBarcode?
     /// A delegate that notifies when the session transitions to the next page
     public var delegate:OTOSessionDelegate?
     
@@ -36,7 +36,7 @@ public class OTOSession {
     /// Function that starts a new session
     public static func startSession(withExperience experience:OTOExperience,
                              product:OTOProduct? = nil,
-                             barcode:String? = nil,
+                             barcode:OTOBarcode? = nil,
                              complete: @escaping (OTOSession?, OTOError?) -> Void) {
         self.startSession(withExperienceId: experience.id, product:product, barcode:barcode, complete: complete)
     }
@@ -44,17 +44,17 @@ public class OTOSession {
     /// Function that starts a new session with a *experienceID*
     public static func startSession(withExperienceId experienceId:Int,
                                     product:OTOProduct? = nil,
-                                    barcode:String? = nil,
+                                    barcode:OTOBarcode? = nil,
                                     complete: @escaping (OTOSession?, OTOError?) -> Void) {
         let endpoint = "experiences/\(experienceId)/sessions"
         var body:[String: Any] = [:]
         if let product = product {
             body["product_url"] = product.url
-            if let barcodeData = product.barcodeData {
+            if let barcodeData = product.barcode?.data {
                 body["barcode_data"] = barcodeData
             }
         } else if let barcode = barcode {
-            body["barcode_data"] = barcode
+            body["barcode_data"] = barcode.data
         }
         
         if let currentLocation = OTOLocationHelper.shared.currentLocation {
@@ -66,7 +66,7 @@ public class OTOSession {
                                       body: body) { (responseObject, error) in
                                         if let responseObject = responseObject {
                                             let session = self.decode(responseObject.dataValue())
-                                            session.barcode = body["barcode_data"] as? String
+                                            session.barcode = barcode
                                             session.product = product
                                             complete(session, nil)
                                         } else {


### PR DESCRIPTION
- replace usage of String to pass barcode data around, so update type of properties in OTOSession and OTOProduct, parameters in functions and delegate callbacks
- move the arrays of support barcode types from OTOCaptureView.swift to Barcodes.swift
- introduce a new error case, for when something breaks around barcode data during communication with the platform
- move the AVCaptureMetadataOutputObjectsDelegate into an extension
- instead of representing exceptional circumstances with an empty barcode string in OTOCaptureView.processBarcode, have it return an optional OTOBarcode
- extract the barcode type in OTOCaptureView.processBarcode