### PR TITLE
add new OTOError case to report double FNC prefix error

### DIFF
--- a/OTOnexus/Classes/Capture/OTOCaptureView.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureView.swift
@@ -301,6 +301,11 @@ class OTOCaptureView: UIView {
     }
     
     fileprivate func didCapture(barcode: OTOBarcode) {
+        guard !barcode.data.isEmpty else {
+            delegate?.barcodeParseError(barcode: barcode)
+            return
+        }
+
         OTOProduct.search(barcode: barcode) { (product, error) in
             if let product = product {
                 product.barcode = barcode

--- a/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
+++ b/OTOnexus/Classes/Capture/OTOCaptureViewController.swift
@@ -24,6 +24,12 @@ public protocol OTOCaptureViewDelegate: class {
     func scannedBarcodeDoesNotExist(barcode: OTOBarcode)
 
     /**
+     Called if the scanning subsystem detects and capture the barcode, but fails to parse the data inside it. One example is when the barcode data contains two FNC sequences as a prefix: in that case, AVFoundation returns an empty string.
+     - Parameter barcode: returned struct containing the autocaptured image of the problem barcode.
+     */
+    func barcodeParseError(barcode: OTOBarcode)
+
+    /**
      Delegate method called if some other error occurred, e.g. networking or authentication.
      - Parameter error: description of the error
      */


### PR DESCRIPTION
AVFoundation doesn't read barcodes correctly if they have a prefix containing two FNC control sequences, and just returns an empty string. We also use empty strings for representing a barcode that was successfully scanned but not recongnized by platform. To differentiate these two cases, we introduce a new OTOError case and use the didEncounterError(error:) delegate callback instead of scannedBarcodeDoesNotExist(barcode:)